### PR TITLE
feat: enable TLS support for endpoints (Influx, MQTT) that use SSL certs

### DIFF
--- a/images/alpine/build-context/Dockerfile
+++ b/images/alpine/build-context/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:${alpineVersion} as builder
 RUN apk add --no-cache --virtual .buildDeps \
     build-base \
     libusb-dev \
+    libressl-dev \
     librtlsdr-dev \
     cmake \
     git
@@ -15,7 +16,7 @@ WORKDIR ./rtl_433
 ARG rtl433GitRevision=master
 RUN git checkout ${rtl433GitRevision}
 WORKDIR ./build
-RUN cmake ..
+RUN cmake -DENABLE_OPENSSL=ON ..
 RUN make -j 4
 RUN cat Makefile
 WORKDIR /build/root

--- a/images/debian/build-context/Dockerfile
+++ b/images/debian/build-context/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libusb-1.0-0-dev \
     libsoapysdr-dev \
+    libssl-dev \
     librtlsdr-dev \
  && rm -rf /var/lib/apt/lists/*
 
@@ -17,7 +18,7 @@ WORKDIR ./rtl_433
 ARG rtl433GitRevision=master
 RUN git checkout ${rtl433GitRevision}
 WORKDIR ./build
-RUN cmake ..
+RUN cmake -DENABLE_OPENSSL=ON ..
 RUN make -j 4
 RUN cat Makefile
 WORKDIR /build/root


### PR DESCRIPTION
Re-created pr to allow checks to run without updating the pipeline.
Full credit goes to @mylesagray
Original PR https://github.com/hertzg/rtl_433_docker/pull/20