### PR TITLE
fix(debian): add libssl runtime dependency

### DIFF
--- a/images/debian/build-context/Dockerfile
+++ b/images/debian/build-context/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     libusb-1.0-0 \
     librtlsdr0 \
     libsoapysdr0.6 \
+    libssl1.1 \
     soapysdr0.6-module-all \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #25 