### PR TITLE
chore: revert use gcr mirror to avoid pull limits

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -70,10 +70,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-        with:
-          config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Reverts hertzg/rtl_433_docker#37