### PR TITLE
fix: rollback alpine to 3.18

### DIFF
--- a/src/alpine.config.ts
+++ b/src/alpine.config.ts
@@ -13,7 +13,10 @@ const fetchLastAlpineCycleVersions = async () => {
     lts: boolean;
   }>;
 
-  return cycles.slice(0, 2).map((cycles) => cycles.latest);
+  return cycles
+    .filter((cycle) => cycle.cycle !== "3.19")
+    .slice(0, 2)
+    .map((cycles) => cycles.latest);
 };
 
 const ALPINE_VERSIONS = await fetchLastAlpineCycleVersions();
@@ -27,7 +30,7 @@ const generateTags = (baseVersion: string, gitRef: string) => {
       ...[
         `${gitRef}-alpine-${semMinor(baseVersion)}`,
         `${gitRef}-alpine-${semMajor(baseVersion)}`,
-      ],
+      ]
     );
   }
 
@@ -93,7 +96,7 @@ export const createAlpineBuildTasks = (gitRefs: string[]): BuildTask[] => {
         cacheFrom: `type=gha,scope=alpine-${alpineVersion}-${gitRef}`,
         cacheTo: `type=gha,scope=alpine-${alpineVersion}-${gitRef}`,
       };
-    },
+    }
   );
 
   return tasks;


### PR DESCRIPTION
Rolling back alpine to 3.18 until https://gitlab.alpinelinux.org/alpine/aports/-/issues/15563 is resolved