### PR TITLE
fix: add CMAKE_POLICY_VERSION_MINIMUM for older rtl_433 versions

### DIFF
--- a/images/alpine/build-context/Dockerfile
+++ b/images/alpine/build-context/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /build
 ADD ./rtl_433 ./rtl_433
 WORKDIR ./rtl_433
 WORKDIR ./build
-RUN cmake -DENABLE_OPENSSL=ON ..
+RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENABLE_OPENSSL=ON ..
 RUN make
 WORKDIR /build/root
 WORKDIR /build/rtl_433/build

--- a/images/debian/build-context/Dockerfile
+++ b/images/debian/build-context/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /build
 ADD ./rtl_433 ./rtl_433
 WORKDIR ./rtl_433
 WORKDIR ./build
-RUN cmake -DENABLE_OPENSSL=ON ..
+RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENABLE_OPENSSL=ON ..
 RUN make
 WORKDIR /build/root
 WORKDIR /build/rtl_433/build


### PR DESCRIPTION
## Summary
- Adds `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to cmake commands in both Alpine and Debian Dockerfiles
- Fixes builds for older rtl_433 versions (0.1, 18.05, 18.12, 19.08, 21.05, 21.12) that have `cmake_minimum_required(VERSION 2.x)`

## Why
CMake 3.30+ removed support for `cmake_minimum_required` versions below 3.5. This causes builds to fail with:
```
CMake Error: Compatibility with CMake < 3.5 has been removed from CMake.
```

## Impact
- No change to build output or resulting binaries
- Only affects CMake's policy version interpretation
- Ignored by newer rtl_433 versions that already specify CMake 3.x+