### PR TITLE
fix(debian): exclude 18.12 from trixie builds

### DIFF
--- a/src/debian.config.ts
+++ b/src/debian.config.ts
@@ -27,6 +27,7 @@ const DEBIAN_LATEST_VERSION = DEBIAN_VERSIONS[0];
 
 const BROKEN_RTLVERSIONS_FOR_DEBIAN_CYCLES = new Map([
   ["bookworm", ["19.08", "18.12"]],
+  ["trixie", ["18.12"]],
 ]);
 
 const generateTags = (baseVersion: string, gitRef: string) => {


### PR DESCRIPTION
## Summary
- Excludes rtl_433 version 18.12 from Debian Trixie builds
- Uses existing `BROKEN_RTLVERSIONS_FOR_DEBIAN_CYCLES` mechanism

## Why
rtl_433 18.12 fails to compile on Debian Trixie due to code incompatibilities with newer compilers/libraries. The build fails during `make` with exit code 2.