### PR TITLE
fix(cache): clone rtl_433 inside Dockerfile for reliable layer caching

### DIFF
--- a/.github/workflows/build-group.yml
+++ b/.github/workflows/build-group.yml
@@ -42,7 +42,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: git clone --branch ${{ matrix.gitRef }} https://github.com/merbanan/rtl_433 ${{ matrix.context }}/rtl_433
       - uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}

--- a/images/alpine/build-context/Dockerfile
+++ b/images/alpine/build-context/Dockerfile
@@ -11,9 +11,15 @@ RUN apk add --no-cache --virtual .buildDeps \
 
 WORKDIR /build
 
-ADD ./rtl_433 ./rtl_433
-WORKDIR ./rtl_433
-WORKDIR ./build
+# Clone rtl_433 inside the Dockerfile for better layer caching
+# The cache key is based on the ARG values, not file timestamps
+# rtl433GitSha is used to bust cache when branch HEAD changes (e.g., master)
+ARG rtl433GitVersion=master
+ARG rtl433GitSha=latest
+RUN git clone --depth 1 --branch ${rtl433GitVersion} https://github.com/merbanan/rtl_433 ./rtl_433 \
+    && echo "Built from ${rtl433GitVersion} @ ${rtl433GitSha}"
+
+WORKDIR ./rtl_433/build
 RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENABLE_OPENSSL=ON ..
 RUN make
 WORKDIR /build/root

--- a/images/debian/build-context/Dockerfile
+++ b/images/debian/build-context/Dockerfile
@@ -13,9 +13,15 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-ADD ./rtl_433 ./rtl_433
-WORKDIR ./rtl_433
-WORKDIR ./build
+# Clone rtl_433 inside the Dockerfile for better layer caching
+# The cache key is based on the ARG values, not file timestamps
+# rtl433GitSha is used to bust cache when branch HEAD changes (e.g., master)
+ARG rtl433GitVersion=master
+ARG rtl433GitSha=latest
+RUN git clone --depth 1 --branch ${rtl433GitVersion} https://github.com/merbanan/rtl_433 ./rtl_433 \
+    && echo "Built from ${rtl433GitVersion} @ ${rtl433GitSha}"
+
+WORKDIR ./rtl_433/build
 RUN cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENABLE_OPENSSL=ON ..
 RUN make
 WORKDIR /build/root

--- a/src/alpine.config.ts
+++ b/src/alpine.config.ts
@@ -41,7 +41,10 @@ const generateTags = (baseVersion: string, gitRef: string) => {
   return tags;
 };
 
-export const createAlpineBuildTasks = (gitRefs: string[]): BuildTask[] => {
+export const createAlpineBuildTasks = (
+  gitRefs: string[],
+  gitRefShas: Map<string, string>
+): BuildTask[] => {
   const [latestGitRef] = sortRtl433TagsDesc(gitRefs);
 
   const variants = gitRefs.flatMap((gitRef) =>
@@ -75,6 +78,8 @@ export const createAlpineBuildTasks = (gitRefs: string[]): BuildTask[] => {
         tags.push("latest");
       }
 
+      const gitSha = gitRefShas.get(gitRef) ?? "unknown";
+
       return {
         name: `${gitRef}-alpine-${alpineVersion}`,
         gitRef: gitRef,
@@ -83,6 +88,7 @@ export const createAlpineBuildTasks = (gitRefs: string[]): BuildTask[] => {
         tags,
         buildArgs: {
           rtl433GitVersion: gitRef,
+          rtl433GitSha: gitSha,
           alpineVersion: alpineVersion,
         },
         platforms: [

--- a/src/debian.config.ts
+++ b/src/debian.config.ts
@@ -40,7 +40,10 @@ const generateTags = (baseVersion: string, gitRef: string) => {
   return tags;
 };
 
-export const createDebianBuildTasks = (gitRefs: string[]): BuildTask[] => {
+export const createDebianBuildTasks = (
+  gitRefs: string[],
+  gitRefShas: Map<string, string>
+): BuildTask[] => {
   const [latestGitRef] = sortRtl433TagsDesc(gitRefs);
 
   const variants = gitRefs.flatMap((gitRef) =>
@@ -81,6 +84,8 @@ export const createDebianBuildTasks = (gitRefs: string[]): BuildTask[] => {
         tags.push(...generateTags("latest", "latest"));
       }
 
+      const gitSha = gitRefShas.get(gitRef) ?? "unknown";
+
       return {
         name: `${gitRef}-debian-${debianVersion}`,
         gitRef: gitRef,
@@ -89,6 +94,7 @@ export const createDebianBuildTasks = (gitRefs: string[]): BuildTask[] => {
         tags,
         buildArgs: {
           rtl433GitVersion: gitRef,
+          rtl433GitSha: gitSha,
           debianVersion: debianVersion,
         },
         platforms: [

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,3 +16,17 @@ export const getGithubRepoTags = async (
   const tags = await res.json();
   return tags;
 };
+
+export interface GithubCommit {
+  sha: string;
+  url: string;
+}
+
+export const getGithubRefCommit = async (
+  repo: string,
+  ref: string,
+): Promise<GithubCommit> => {
+  const res = await fetch(`https://api.github.com/repos/${repo}/commits/${ref}`);
+  const commit = await res.json();
+  return { sha: commit.sha, url: commit.url };
+};


### PR DESCRIPTION
## Summary

- Move git clone from workflow to Dockerfile to fix inconsistent cache hits
- Add `rtl433GitSha` build arg for cache busting when branch HEAD changes
- Remove external git clone step from workflow (smaller build context)

## Problem

The `ADD ./rtl_433 ./rtl_433` instruction was causing cache invalidation because:
1. Each `git clone` produces files with fresh timestamps
2. The `.git` directory contains volatile metadata that changes with every clone
3. Docker's ADD/COPY cache is based on file checksums, which vary due to metadata differences

This resulted in cache sometimes working and sometimes not, even for identical source code.

## Solution

Clone rtl_433 **inside** the Dockerfile using build ARGs:
- `rtl433GitVersion`: The branch or tag to clone (e.g., `master`, `24.10`)
- `rtl433GitSha`: The commit SHA for cache busting

Cache behavior:
- **Tagged releases** (e.g., `24.10`): Cache is stable since SHA is immutable
- **Branches** (e.g., `master`): Cache invalidates correctly when new commits arrive

## Test plan

- [ ] Verify build succeeds for Alpine images
- [ ] Verify build succeeds for Debian images
- [ ] Verify cache is used on subsequent builds with same SHA
- [ ] Verify cache is invalidated when master branch has new commits