### PR TITLE
perf: remove IBM architectures, keep ARM for Raspberry Pi support

### DIFF
--- a/.github/workflows/build-group.yml
+++ b/.github/workflows/build-group.yml
@@ -10,7 +10,15 @@ on:
         required: true
         type: boolean
         default: false
-      manifests:
+      manifestGroup:
+        required: false
+        type: string
+        default: ""
+      manifestTags:
+        required: false
+        type: string
+        default: ""
+      manifestPlatforms:
         required: false
         type: string
         default: ""
@@ -53,13 +61,17 @@ jobs:
           cache-from: ${{ matrix.cacheFrom }}
           cache-to: ${{ matrix.cacheTo }}
           tags: ${{ matrix.tags }}
-  
+
+  # Single manifest job per group - runs after all platform builds complete
+  # Concurrency ensures only one manifest update runs at a time per group
   manifest:
-    if: ${{ inputs.push && inputs.manifests != '' }}
-    name: 📦 Manifests
-    needs: 
-      - build
+    name: 📦 Manifest
+    needs: build
+    if: ${{ inputs.push && inputs.manifestTags != '' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: manifest-${{ inputs.manifestGroup }}
+      cancel-in-progress: false
     steps:
       - uses: docker/setup-buildx-action@v3
         with:
@@ -76,4 +88,35 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: ${{ inputs.manifests }}
+      - name: Create multi-arch manifests
+        env:
+          MANIFEST_TAGS: ${{ inputs.manifestTags }}
+          PLATFORMS: ${{ inputs.manifestPlatforms }}
+        run: |
+          # Process each manifest tag
+          echo "$MANIFEST_TAGS" | while read -r manifest_tag; do
+            [ -z "$manifest_tag" ] && continue
+
+            echo "Processing manifest: $manifest_tag"
+
+            # Collect all available platform images
+            SOURCES=""
+            for plat in $PLATFORMS; do
+              source_tag="${manifest_tag}-${plat}"
+              if docker buildx imagetools inspect "$source_tag" >/dev/null 2>&1; then
+                SOURCES="$SOURCES $source_tag"
+                echo "  Found: $source_tag"
+              else
+                echo "  Missing: $source_tag"
+              fi
+            done
+
+            # Create manifest with all sources
+            if [ -n "$SOURCES" ]; then
+              echo "  Creating manifest: $manifest_tag"
+              docker buildx imagetools create -t "$manifest_tag" $SOURCES
+            else
+              echo "  Error: no source images found for $manifest_tag"
+              exit 1
+            fi
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,7 @@ jobs:
     with:
       tasks: ${{ toJson(matrix.tasks) }}
       push: ${{ github.ref == 'refs/heads/master' || github.event_name == 'schedule' }}
-      manifests: ${{ matrix.manifests }}
+      manifestGroup: ${{ matrix.manifestGroup }}
+      manifestTags: ${{ matrix.manifestTags }}
+      manifestPlatforms: ${{ matrix.manifestPlatforms }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -212,14 +212,12 @@ services:
 
 ## Supported Platforms
 
-| Architecture | Alpine | Debian |
-|--------------|--------|--------|
-| `linux/amd64` | ✅ | ✅ |
-| `linux/arm64` | ✅ | ✅ |
-| `linux/arm/v7` | ✅ | ✅ |
-| `linux/arm/v6` | ✅ | ❌ |
-| `linux/ppc64le` | ✅ | ✅ |
-| `linux/s390x` | ❌ | ✅ |
+| Architecture | Alpine | Debian | Devices |
+|--------------|--------|--------|---------|
+| `linux/amd64` | ✅ | ✅ | x86_64 PCs, servers |
+| `linux/arm64` | ✅ | ✅ | Raspberry Pi 4/5, Apple Silicon |
+| `linux/arm/v7` | ✅ | ✅ | Raspberry Pi 2/3 (32-bit) |
+| `linux/arm/v6` | ✅ | ❌ | Raspberry Pi Zero/1 |
 
 ## Troubleshooting
 

--- a/src/alpine.config.ts
+++ b/src/alpine.config.ts
@@ -96,8 +96,6 @@ export const createAlpineBuildTasks = (
           "linux/arm64/v8",
           "linux/arm/v6",
           "linux/arm/v7",
-          "linux/ppc64le",
-          // "linux/386",
         ],
         cacheFrom: `type=gha,scope=alpine-${alpineVersion}-${gitRef}`,
         cacheTo: `type=gha,scope=alpine-${alpineVersion}-${gitRef}`,

--- a/src/debian.config.ts
+++ b/src/debian.config.ts
@@ -99,10 +99,8 @@ export const createDebianBuildTasks = (
         },
         platforms: [
           "linux/amd64",
-          "linux/arm/v7",
           "linux/arm64/v8",
-          "linux/ppc64le",
-          "linux/s390x",
+          "linux/arm/v7",
         ],
         cacheFrom: `type=gha,scope=debian-${debianVersion}-${gitRef}`,
         cacheTo: `type=gha,scope=debian-${debianVersion}-${gitRef}`,


### PR DESCRIPTION
## Summary

- Remove ppc64le and s390x (no SDR use case on IBM servers/mainframes)
- Keep amd64, arm64/v8 (native GitHub runners)
- Keep arm/v6, arm/v7 (QEMU, but needed for Raspberry Pi support)
- Use concurrency groups to serialize manifest updates per image group
- Platform list flows from config to workflow (single source of truth)
- Update README with supported platforms

## Architecture Changes

| Architecture | Status | Runner | Reason |
|-------------|--------|--------|--------|
| linux/amd64 | ✅ Keep | Native | x86_64 PCs, servers |
| linux/arm64/v8 | ✅ Keep | Native | RPi 4/5, Apple Silicon |
| linux/arm/v7 | ✅ Keep | QEMU | RPi 2/3 (32-bit) |
| linux/arm/v6 | ✅ Keep (Alpine) | QEMU | RPi Zero/1 |
| linux/ppc64le | ❌ Remove | - | No SDR use case |
| linux/s390x | ❌ Remove | - | No SDR use case |

## Build Time

| Removed | Saved |
|---------|-------|
| ppc64le (~24min) | ✅ |
| s390x (~22min) | ✅ |

~46 min saved per image by removing unused IBM architectures.

## Single Source of Truth

Platform configuration flows from TypeScript config → workflow:

```
alpine.config.ts / debian.config.ts
            ↓
        main.ts (manifestPlatforms)
            ↓
        build.yml
            ↓
        build-group.yml (PLATFORMS env)
```

No hardcoded platform lists in workflow files.

## Manifest Concurrency

```yaml
concurrency:
  group: manifest-${{ inputs.manifestGroup }}
  cancel-in-progress: false
```

Prevents race conditions when multiple workflow runs update the same manifest.

## Files Changed

- `src/alpine.config.ts` - Remove ppc64le
- `src/debian.config.ts` - Remove ppc64le, s390x
- `src/main.ts` - Add manifestPlatforms output
- `.github/workflows/build.yml` - Pass manifestPlatforms
- `.github/workflows/build-group.yml` - Use manifestPlatforms input, add concurrency
- `README.md` - Update supported platforms table

## Test plan

- [ ] Verify native builds (amd64, arm64) complete quickly
- [ ] Verify QEMU builds (arm/v6, arm/v7) complete
- [ ] Verify multi-arch manifest includes all platforms
- [ ] Verify ppc64le and s390x are NOT built